### PR TITLE
Support for intersection and union types.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # classy-optics
-![Maven](https://img.shields.io/maven-central/v/pismute/classy-mtl_3.svg?style=flat-square)
+![Maven](https://img.shields.io/maven-central/v/io.github.pismute/classy-mtl_3.svg?style=flat-square)
 
 It is built for [meow-mtl] again in Scala 3.
 
@@ -8,8 +8,8 @@ It provides the similar functionality with [meow-mtl], but limited magics in Sca
 Available for Scala JVM, Scalajs and Scala Native:
 
 ```scala
-libraryDependencies += "io.github.pismute" %% "classy-mtl" % "0.1.0"
-libraryDependencies += "io.github.pismute" %% "classy-effect" % "0.1.0"
+libraryDependencies += "io.github.pismute" %% "classy-mtl" % "<version>"
+libraryDependencies += "io.github.pismute" %% "classy-effect" % "<version>"
 ```
 
 Inspired by [Next-level MTL talk][mtl-talk] and [meow-mtl]
@@ -195,6 +195,80 @@ for
   _ = summon[Ref[AppT, HttpCache]]
 yield ... 
 ```
+
+## Intersection Type.
+
+An intersection type is a type alias, it is a product-like alias. We can think the cardinality of `ProductLike` is 4 as of a product of `HasBoolean1`'s one and `HasBoolean2`'s one:
+
+```scala
+case class HasBoolean1(b: Boolean)
+case class HasBoolean2(b: Boolean)
+
+type ProductLike = HasBoolean1 & HasBoolean2
+```
+
+Maybe, We might use Intersection type in our data. Compiler does not provide goodies like `case class`, though, there is some free lunches from the type inference. For example:
+
+```scala
+trait DbConfig:
+  def dbPort: Int
+  
+trait HttpConfig:
+  def httpPort: Int
+  
+case case AppConfigCake(dbPort: Int, httpPort: Int) extends DbConfig with HttpConfig derives Show
+
+type AppConfig = DbConfig & HttpConfig
+```
+
+`AppConfigCake` is needed to materialize AppConfig. Also we can take `case class`'s goodies like `derives Show`, in this case.
+
+As a product type, intersection types can have optics. AppConfig is visible as DbConfig or HttpConfig. So, intersection types can have `Getter` instances. If it has `Getter` instances, then we can derive Ask instances automatically. It is the idea of this library.
+
+However, we do not need even `Getter` instances for intersection types to have Ask instances, because Ask is covariant. `Ask[F[_], +E]`'s `E` is covariant. When we ask Scala compiler to bring Ask instances from `given` space, the compiler will bring the instance what exactly we want. The compiler will bring `Ask[F[_], AppConfig]` instance for `Ask[F[_], DbConfig]` without optics. It is free lunches, free optics.
+
+Intersection types can not have `Lens` optic, because they do not have the standard way of mutation, which is a way of `set`. Without `Lens` optics, narrowing `Local` and `Stateful` can not work with intersection types.
+
+So, `classy-optics` does not provide any optics for intersection types.
+
+## Union Type.
+
+Union type is a sum-like alias, the cardinality of `AppError` is 4 as of a sum of `DbError` and `HttpError`:
+
+```scala
+enum DbError:
+  case LostConnection, ExceedLimit
+  
+enum HttpError:
+  case LostConnection, ExceedLimit
+
+type AppError = DbError | HttpError
+```
+
+Unlike intersection types, Mutation is not required for Prism types. They can have both of a `Prism` instance and a `Review` instance. It is simple:
+
+```scala
+class APrism[AppError, DbError] extends Prism[AppError, DbError]:
+  def preview: AppError => Option[DbError] = { case x: DbError => x }.lift
+  def review: DbError => AppError = x => x
+```
+
+Also, like `Ask[F[_], +E]` type class, the parameters of `Raise[F[_], -E]` and `Tell[F[_], -L]` are contravariant. So deriving their sub instances is not needed. If `Raise[F[_], AppError]` and `Tell[F[_], AppError]` exists in given space. Compiler will return those instances for `Raise[F[_], DbError]`,  `Tell[F[_], DbError]` and so on. In case of `Raise` and `Tell`, we do not need optics.
+
+But, `Handle[F[_], E]`'s type parameter is invariant. we will not get `Handle[F[_], AppError]` instance for `Handle[F[_], DbError]`. So, `Handle` need a Prism optic to narrow it. 
+
+Now, `classy-optics` provides Prism instances for Union types. It works seamlessly:
+
+```scala
+type AppError = DbError | HttpError 
+
+summon[Raise[F, DbError]] // works if Raise[F, AppError] exists
+
+// works because Prism[AppError, DbError] is derived automatically
+given [F[_]](using Handle[F, AppError]): Raise[F, DbError] = deriveHandle
+```
+
+Ok, it looks simpler than `enum AppError`. But, yet, it is not. There are no instances for essential type classes like `Eq`, `Show` and so on. The instances need to be provided manually.
 
 ## License
 MIT

--- a/mtl/shared/src/main/scala/classy/mtl/deriving.scala
+++ b/mtl/shared/src/main/scala/classy/mtl/deriving.scala
@@ -1,10 +1,14 @@
 package classy.mtl
 
-import cats.{Applicative, Functor, Monad}
+import cats.Applicative
+import cats.Functor
+import cats.Monad
 import cats.mtl.*
-
 import classy.mtl.internal.*
-import classy.optics.{Getter, Lens, Prism, Review}
+import classy.optics.Getter
+import classy.optics.Lens
+import classy.optics.Prism
+import classy.optics.Review
 
 trait deriving:
 
@@ -19,7 +23,7 @@ trait deriving:
   def deriveRaise[F[_], A, B: PinInvariant](using parent: Raise[F, A], review: Review[A, B]): Raise[F, B] =
     ReviewRaise(parent, review)
 
-  def deriveHandle[F[_], A <: Matchable, B](using parent: Handle[F, A], prism: Prism[A, B]): Handle[F, B] =
+  def deriveHandle[F[_], A, B](using parent: Handle[F, A], prism: Prism[A, B]): Handle[F, B] =
     PrismHandle(parent, prism)
 
   def deriveTell[F[_], A, B: PinInvariant](using parent: Tell[F, A], review: Review[A, B]): Tell[F, B] =

--- a/mtl/shared/src/main/scala/classy/mtl/internal/PrismHandle.scala
+++ b/mtl/shared/src/main/scala/classy/mtl/internal/PrismHandle.scala
@@ -2,10 +2,9 @@ package classy.mtl.internal
 
 import cats.Applicative
 import cats.mtl.Handle
-
 import classy.optics.Prism
 
-private[classy] class PrismHandle[F[_], A <: Matchable, B](parent: Handle[F, A], prism: Prism[A, B])
+private[classy] class PrismHandle[F[_], A, B](parent: Handle[F, A], prism: Prism[A, B])
     extends ReviewRaise[F, A, B](parent, prism)
     with Handle[F, B]:
 

--- a/mtl/shared/src/main/scala/classy/mtl/package.scala
+++ b/mtl/shared/src/main/scala/classy/mtl/package.scala
@@ -1,10 +1,17 @@
 package classy
 
+import cats.mtl.Ask
+import cats.mtl.Handle
+import cats.mtl.Local
+import cats.mtl.Raise
+import cats.mtl.Stateful
+import cats.mtl.Tell
+import classy.optics.Getter
+import classy.optics.Lens
+import classy.optics.Prism
+import classy.optics.Review
+
 import scala.util.NotGiven
-
-import cats.mtl.{Ask, Handle, Local, Raise, Stateful, Tell}
-
-import classy.optics.{Getter, Lens, Prism, Review}
 
 // package object is deprecated, but export on packages has a bug
 // https://github.com/lampepfl/dotty/issues/17201
@@ -38,7 +45,7 @@ package object mtl extends deriving with syntax:
     ): Raise[F, B] =
       deriveRaise
 
-    given [F[_], A <: Matchable, B](using
+    given [F[_], A, B](using
         NotGiven[Handle[F, B]],
         Handle[F, A],
         Prism[A, B]

--- a/mtl/shared/src/main/scala/classy/optics/Macros.scala
+++ b/mtl/shared/src/main/scala/classy/optics/Macros.scala
@@ -1,0 +1,19 @@
+package classy.optics
+
+import scala.quoted.*
+import scala.quoted.runtime.*
+
+private[classy] object Macros:
+  def showTypeAlias[T: Type](using Quotes): String =
+    import quotes.reflect.*
+
+    s"type ${Type.show[T]} = ${TypeRepr.of[T].dealias.show}"
+
+  def assertNonIdenticalType[A: Type, B: Type](using Quotes): Unit =
+    import quotes.reflect.*
+
+    if TypeRepr.of[A].=:=(TypeRepr.of[B]) then
+      report.errorAndAbort(s"${Type.show[A]} must not be identical to ${Type.show[B]}")
+    else ()
+
+end Macros

--- a/mtl/shared/src/main/scala/classy/optics/Prism.scala
+++ b/mtl/shared/src/main/scala/classy/optics/Prism.scala
@@ -52,5 +52,5 @@ private[classy] object Prism:
   inline def fromPF[S, A](_preview: => PartialFunction[S, A])(_review: A => S): Prism[S, A] =
     apply[S, A](_preview.lift)(_review)
 
-  inline given derived[S <: Matchable, A]: Prism[S, A] = ${ SumMacros.genPrism[S, A] }
+  inline given derived[S, A]: Prism[S, A] = ${ SumMacros.genPrism[S, A] }
 end Prism

--- a/mtl/shared/src/main/scala/classy/optics/ProductMacros.scala
+++ b/mtl/shared/src/main/scala/classy/optics/ProductMacros.scala
@@ -1,5 +1,7 @@
 package classy.optics
 
+import Macros.*
+
 import scala.compiletime.*
 import scala.deriving.*
 import scala.quoted.*
@@ -36,6 +38,8 @@ private[classy] object ProductMacros:
   def genGetter[T <: Product: Type, A: Type](using q: Quotes): Expr[Getter[T, A]] =
     import quotes.reflect.*
 
+    assertNonIdenticalType[T, A]
+
     Expr
       .summon[Mirror.ProductOf[T]]
       .map { case '{ $m: Mirror.ProductOf[T] { type MirroredElemTypes = elementTypes } } =>
@@ -53,6 +57,8 @@ private[classy] object ProductMacros:
 
   def genIso[T <: Product: Type, A: Type](using q: Quotes): Expr[Iso[T, A]] =
     import quotes.reflect.*
+
+    assertNonIdenticalType[T, A]
 
     Expr
       .summon[Mirror.ProductOf[T]]
@@ -72,6 +78,8 @@ private[classy] object ProductMacros:
 
   def genLens[T <: Product: Type, A: Type](using q: Quotes): Expr[Lens[T, A]] =
     import quotes.reflect.*
+
+    assertNonIdenticalType[T, A]
 
     Expr
       .summon[Mirror.ProductOf[T]]

--- a/mtl/shared/src/main/scala/classy/optics/SumMacros.scala
+++ b/mtl/shared/src/main/scala/classy/optics/SumMacros.scala
@@ -1,65 +1,98 @@
 package classy.optics
 
+import Macros.*
+
 import scala.compiletime.*
 import scala.deriving.*
 import scala.quoted.*
-
 private[classy] object SumMacros:
+  private type PrismOr[T, A] = Either[String, Expr[Prism[T, A]]]
+  private type ReviewOr[T, A] = Either[String, Expr[Review[T, A]]]
+
   private def reviewOf[T: Type, A: Type](using Quotes): Expr[Review[T, A]] =
     val review: Expr[A => T] = '{ a => a.asInstanceOf[T] }
     '{ Review[T, A]($review) }
 
-  private def mkReview[S: Type, T: Type, A: Type](using Quotes): Option[Expr[Review[S, A]]] =
+  private def mkReview[S: Type, T: Type, A: Type](using Quotes): ReviewOr[S, A] =
     Type.of[T] match
-      case '[A *: tpes] => Some(reviewOf[S, A])
+      case '[A *: tpes] => Right(reviewOf[S, A])
       case '[tpe *: tpes] =>
         Expr.summon[Iso[tpe, A]] match
           case None => mkReview[S, tpes, A]
           case Some(iso) =>
-            Some('{ ${ iso }.composeReview(${ reviewOf[S, tpe] }) })
-      case _ => None
+            Right('{ ${ iso }.composeReview(${ reviewOf[S, tpe] }) })
+      case _ => Left(s"${Type.show[A]} cannot reach in ${Type.show[T]}")
   end mkReview
+
+  private def genEnumReview[T: Type, A: Type](using q: Quotes): ReviewOr[T, A] =
+    import quotes.reflect.*
+
+    Expr
+      .summon[Mirror.SumOf[T]]
+      .toRight(s"${Type.show[T]} is not a sum type")
+      .flatMap { case '{ $m: Mirror.SumOf[T] { type MirroredElemTypes = elementTypes } } =>
+        mkReview[T, elementTypes, A]
+      }
+  end genEnumReview
 
   def genReview[T: Type, A: Type](using q: Quotes): Expr[Review[T, A]] =
     import quotes.reflect.*
 
-    Expr
-      .summon[Mirror.SumOf[T]]
-      .map { case '{ $m: Mirror.SumOf[T] { type MirroredElemTypes = elementTypes } } =>
-        mkReview[T, elementTypes, A].getOrElse(
-          report.errorAndAbort(s"${Type.show[A]} cannot reach in ${Type.show[T]}")
-        )
-      }
-      .getOrElse(report.errorAndAbort(s"${Type.show[T]} is not a sum type"))
+    assertNonIdenticalType[T, A]
+
+    genEnumReview[T, A].fold(report.errorAndAbort, identity)
   end genReview
 
-  private def prismOf[T <: Matchable: Type, A: Type](using Quotes): Expr[Prism[T, A]] =
+  private def prismOf[T: Type, A: Type](using Quotes): Expr[Prism[T, A]] =
     val preview: Expr[PartialFunction[T, A]] = '{ { case a: A => a } }
     val review: Expr[A => T] = '{ a => a.asInstanceOf[T] }
     '{ Prism.fromPF[T, A]($preview)($review) }
 
-  private def mkPrism[S <: Matchable: Type, T: Type, A: Type](using Quotes): Option[Expr[Prism[S, A]]] =
+  private def mkPrism[S: Type, T: Type, A: Type](using Quotes): PrismOr[S, A] =
     Type.of[T] match
-      case '[A *: tpes] => Some(prismOf[S, A])
+      case '[A *: tpes] => Right(prismOf[S, A])
       case '[tpe *: tpes] =>
         Expr.summon[Iso[tpe, A]] match
           case None => mkPrism[S, tpes, A]
           case Some(iso) =>
-            Some('{ $iso.composePrism(${ prismOf[S, tpe] }) })
-      case _ => None
+            Right('{ $iso.composePrism(${ prismOf[S, tpe] }) })
+      case _ => Left(s"${Type.show[A]} cannot reach in ${Type.show[T]}")
   end mkPrism
 
-  def genPrism[T <: Matchable: Type, A: Type](using q: Quotes): Expr[Prism[T, A]] =
+  private def genEnumPrism[T: Type, A: Type](using q: Quotes): PrismOr[T, A] =
     import quotes.reflect.*
 
     Expr
       .summon[Mirror.SumOf[T]]
-      .map { case '{ $m: Mirror.SumOf[T] { type MirroredElemTypes = elementTypes } } =>
-        mkPrism[T, elementTypes, A].getOrElse(
-          report.errorAndAbort(s"${Type.show[A]} cannot reach in ${Type.show[T]}")
-        )
+      .toRight(s"${Type.show[T]} is not a sum type")
+      .flatMap { case '{ $m: Mirror.SumOf[T] { type MirroredElemTypes = elementTypes } } =>
+        mkPrism[T, elementTypes, A]
       }
-      .getOrElse(report.errorAndAbort(s"${Type.show[T]} is not a sum type"))
+  end genEnumPrism
+
+  private def genUnionPrism[T: Type, A: Type](using q: Quotes): PrismOr[T, A] =
+    import quotes.reflect.*
+
+    val tRepr = TypeRepr.of[T]
+    val aRepr = TypeRepr.of[A]
+
+    def mkUnionPrism(union: TypeRepr): PrismOr[T, A] =
+      union match
+        case OrType(lhs, rhs)            => mkUnionPrism(lhs).orElse(mkUnionPrism(rhs))
+        case t: TypeRepr if t.=:=(aRepr) => Right(prismOf[T, A])
+        case _                           => Left(s"${showTypeAlias[T]} does not contain ${Type.show[A]}")
+
+    mkUnionPrism(tRepr.dealias)
+  end genUnionPrism
+
+  def genPrism[T: Type, A: Type](using q: Quotes): Expr[Prism[T, A]] =
+    import quotes.reflect.*
+
+    assertNonIdenticalType[T, A]
+
+    genEnumPrism[T, A]
+      .orElse(genUnionPrism[T, A])
+      .fold(report.errorAndAbort, identity)
   end genPrism
 
 end SumMacros

--- a/mtl/shared/src/test/scala/classy/BaseSuite.scala
+++ b/mtl/shared/src/test/scala/classy/BaseSuite.scala
@@ -3,7 +3,12 @@ package classy
 import scala.compiletime.*
 import scala.concurrent.Future
 
-import cats.{~>, Comonad, Eval, Functor, Id}
+import cats.~>
+import cats.Comonad
+import cats.Eval
+import cats.Functor
+import cats.Id
+import cats.arrow.FunctionK
 import cats.syntax.functor.*
 
 import org.scalacheck.Gen
@@ -24,6 +29,9 @@ trait BaseSuite extends DisciplineFSuite with AssertionsF with ScalacheckGens:
       "cats.Eval",
       matchable { case e: Eval[?] => Future(e.value)(munitExecutionContext) }
     )
+
+  val evalToIdK: ~>[Eval, Id] = FunctionK.lift[Eval, Id]([a] => (fa: Eval[a]) => fa.value)
+  val idToEvalK: ~>[Id, Eval] = FunctionK.lift[Id, Eval]([a] => (fa: Id[a]) => Eval.later(fa))
 
 end BaseSuite
 

--- a/mtl/shared/src/test/scala/classy/mtl/internal/HandleSpec.scala
+++ b/mtl/shared/src/test/scala/classy/mtl/internal/HandleSpec.scala
@@ -1,5 +1,7 @@
 package classy.mtl.internal
 
+import cats.~>
+import cats.Eq
 import cats.Eval
 import cats.Id
 import cats.arrow.FunctionK
@@ -8,7 +10,10 @@ import cats.laws.discipline.*
 import cats.laws.discipline.arbitrary.*
 import cats.mtl.Handle
 import cats.mtl.laws.discipline.*
-import cats.~>
+
+import org.scalacheck.Arbitrary
+import org.scalacheck.Gen
+
 import classy.BaseSuite
 import classy.mtl.*
 
@@ -28,6 +33,24 @@ class HandleSpec extends SumBaseSuite with classy.SumData:
       val fk: ~>[M, MM] = FunctionK.lift([a] => (fa: M[a]) => fa.mapK(idToEvalK))
       val gk: ~>[MM, M] = FunctionK.lift([a] => (fa: MM[a]) => fa.mapK(evalToIdK))
       given Handle[MM, MiniInt] = summon[Handle[M, MiniInt]].imapK(fk, gk)
+
+      HandleTests[MM, MiniInt](summon).handle[MiniInt]
+    }
+  )
+
+  checkAll(
+    "derive for a union type", {
+      type Union = MiniInt | Float
+      type MM[A] = EitherT[Id, Union, A]
+      given [F[_]](using Handle[F, Union]): Handle[F, MiniInt] = deriveHandle
+
+      given Arbitrary[Union] = Arbitrary(Gen.oneOf[Union](Arbitrary.arbitrary[MiniInt], Arbitrary.arbitrary[Float]))
+
+      given Eq[Union] = Eq.instance[Union] {
+        case (a: MiniInt, b: MiniInt) if Eq[MiniInt].eqv(a, b) => true
+        case (a: Float, b: Float) if Eq[Float].eqv(a, b)       => true
+        case _                                                 => false
+      }
 
       HandleTests[MM, MiniInt](summon).handle[MiniInt]
     }

--- a/mtl/shared/src/test/scala/classy/mtl/internal/RaiseSpec.scala
+++ b/mtl/shared/src/test/scala/classy/mtl/internal/RaiseSpec.scala
@@ -32,4 +32,18 @@ class RaiseSpec extends SumBaseSuite with classy.SumData:
     }
   )
 
+  test("contravariant test on a union type") {
+    trait DbError
+
+    trait HttpError
+
+    type AppError = DbError | HttpError
+
+    type MM[A] = Either[AppError, A]
+
+    summon[Raise[MM, DbError]]
+
+    summon[Raise[MM, HttpError]]
+  }
+
 end RaiseSpec

--- a/mtl/shared/src/test/scala/classy/mtl/internal/RaiseSpec.scala
+++ b/mtl/shared/src/test/scala/classy/mtl/internal/RaiseSpec.scala
@@ -1,6 +1,8 @@
 package classy.mtl.internal
 
-import cats.{~>, Id}
+import cats.~>
+import cats.Eval
+import cats.Id
 import cats.arrow.FunctionK
 import cats.data.EitherT
 import cats.laws.discipline.*
@@ -12,7 +14,7 @@ import classy.mtl.*
 
 class RaiseSpec extends SumBaseSuite with classy.SumData:
 
-  type M[A] = Either[Data, A]
+  type M[A] = EitherT[Id, Data, A]
   given [F[_]](using Raise[F, Data]): Raise[F, MiniInt] = deriveRaise
 
   checkAll(
@@ -22,11 +24,11 @@ class RaiseSpec extends SumBaseSuite with classy.SumData:
 
   checkAll(
     "Raise.mapK", {
-      type F[A] = EitherT[Id, Data, A]
-      val fk: ~>[M, F] = FunctionK.lift([a] => (ma: M[a]) => EitherT.fromEither[Id](ma))
-      given Raise[F, MiniInt] = summon[Raise[M, MiniInt]].mapK(fk)
+      type MM[A] = EitherT[Eval, Data, A]
+      val fk: ~>[M, MM] = FunctionK.lift([a] => (fa: M[a]) => fa.mapK(idToEvalK))
+      given Raise[MM, MiniInt] = summon[Raise[M, MiniInt]].mapK(fk)
 
-      RaiseTests[F, MiniInt](summon).raise[MiniInt]
+      RaiseTests[MM, MiniInt](summon).raise[MiniInt]
     }
   )
 

--- a/mtl/shared/src/test/scala/classy/mtl/internal/TellSpec.scala
+++ b/mtl/shared/src/test/scala/classy/mtl/internal/TellSpec.scala
@@ -1,8 +1,12 @@
 package classy.mtl.internal
 
-import cats.{~>, Functor, Id}
+import cats.~>
+import cats.Eval
+import cats.Functor
+import cats.Id
 import cats.arrow.FunctionK
-import cats.data.EitherT
+import cats.data.State
+import cats.data.WriterT
 import cats.laws.discipline.*
 import cats.laws.discipline.arbitrary.*
 import cats.mtl.Tell
@@ -12,13 +16,8 @@ import classy.mtl.*
 
 class TellSpec extends SumBaseSuite with classy.SumData:
 
-  type M[A] = Either[Data, A]
+  type M[A] = WriterT[Id, Data, A]
   given [F[_]](using Tell[F, Data]): Tell[F, MiniInt] = deriveTell
-
-  given Tell[M, Data] with
-    def functor: Functor[M] = summon
-
-    def tell(l: Data): M[Unit] = Right(())
 
   checkAll(
     "Tell",
@@ -27,11 +26,11 @@ class TellSpec extends SumBaseSuite with classy.SumData:
 
   checkAll(
     "Tell.mapK", {
-      type F[A] = EitherT[Id, Data, A]
-      val fk: ~>[M, F] = FunctionK.lift([a] => (ma: M[a]) => EitherT.fromEither[Id](ma))
-      given Tell[F, MiniInt] = summon[Tell[M, MiniInt]].mapK(fk)
+      type MM[A] = WriterT[Eval, Data, A]
+      val fk: ~>[M, MM] = FunctionK.lift([a] => (ma: M[a]) => ma.mapK(idToEvalK))
+      given Tell[MM, MiniInt] = summon[Tell[M, MiniInt]].mapK(fk)
 
-      TellTests[F, MiniInt](summon).tell[MiniInt]
+      TellTests[MM, MiniInt](summon).tell[MiniInt]
     }
   )
 end TellSpec

--- a/mtl/shared/src/test/scala/classy/mtl/internal/TellSpec.scala
+++ b/mtl/shared/src/test/scala/classy/mtl/internal/TellSpec.scala
@@ -33,4 +33,24 @@ class TellSpec extends SumBaseSuite with classy.SumData:
       TellTests[MM, MiniInt](summon).tell[MiniInt]
     }
   )
+
+  test("contravariant test on a union type") {
+    trait DbError
+
+    trait HttpError
+
+    type AppError = DbError | HttpError
+
+    type MM[A] = State[AppError, A]
+
+    given Tell[MM, AppError] with
+      def functor: Functor[MM] = summon
+
+      def tell(l: AppError): MM[Unit] = State.set(l)
+
+    summon[Tell[MM, DbError]]
+
+    summon[Tell[MM, HttpError]]
+  }
+
 end TellSpec

--- a/mtl/shared/src/test/scala/classy/optics/GetterSpec.scala
+++ b/mtl/shared/src/test/scala/classy/optics/GetterSpec.scala
@@ -1,6 +1,5 @@
 package classy.optics
 
-// stolen from meow-mtl
 class GetterSpec extends classy.BaseSuite:
   case class HttpConfig(port: Int, address: String)
 

--- a/mtl/shared/src/test/scala/classy/optics/IsoSpec.scala
+++ b/mtl/shared/src/test/scala/classy/optics/IsoSpec.scala
@@ -1,6 +1,5 @@
 package classy.optics
 
-// stolen from meow-mtl
 class IsoSpec extends classy.BaseSuite:
   case class DbConfig(address: String, port: Int)
   case class HttpConfig(port: Int)

--- a/mtl/shared/src/test/scala/classy/optics/LensSpec.scala
+++ b/mtl/shared/src/test/scala/classy/optics/LensSpec.scala
@@ -1,6 +1,5 @@
 package classy.optics
 
-// stolen from meow-mtl
 class LensSpec extends classy.BaseSuite:
   case class HttpConfig(port: Int)
   case class AppConfig(name: String, httpConfig: HttpConfig)

--- a/mtl/shared/src/test/scala/classy/optics/PrismSpec.scala
+++ b/mtl/shared/src/test/scala/classy/optics/PrismSpec.scala
@@ -1,6 +1,5 @@
 package classy.optics
 
-// stolen from meow-mtl
 class PrismSpec extends classy.BaseSuite:
   enum AppError:
     case HttpMsgError(port: Int, msg: String) extends AppError

--- a/mtl/shared/src/test/scala/classy/optics/PrismSpec.scala
+++ b/mtl/shared/src/test/scala/classy/optics/PrismSpec.scala
@@ -49,9 +49,26 @@ class PrismSpec extends classy.BaseSuite:
     assertEquals(iso2.composePrism(prism2).review(2), error2)
   }
 
+  test("defived for union type") {
+    case class DbError(int: Int)
+    case class HttpError(string: String)
+    case class NetError(double: Double)
+    case class CalcError(float: Float)
+
+    type AppError = DbError | HttpError | NetError | CalcError
+
+    val a: AppError = DbError(1)
+
+    summon[Prism[AppError, DbError]]
+    summon[Prism[AppError, HttpError]]
+    summon[Prism[AppError, NetError]]
+    summon[Prism[AppError, CalcError]]
+  }
+
   // test("should fail to compile") {
   //   case class NoConfig()
   //   summon[Prism[NoConfig, Int]]
+  //   summon[Prism[NoConfig, NoConfig]]
   // }
 
 end PrismSpec

--- a/mtl/shared/src/test/scala/classy/optics/ReviewSpec.scala
+++ b/mtl/shared/src/test/scala/classy/optics/ReviewSpec.scala
@@ -1,6 +1,5 @@
 package classy.optics
 
-// stolen from meow-mtl
 class ReviewSpec extends classy.BaseSuite:
   enum AppError:
     case HttpMsgError(port: Int, msg: String) extends AppError


### PR DESCRIPTION
MTL type classes can be narrowed over intersection and union types.